### PR TITLE
chore: bump bevy from 0.15.0-rc3 => 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_simple_i18n"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["TurtIeSocks"]
 license = "MIT OR Apache-2.0"
@@ -20,7 +20,7 @@ default = ["numbers"]
 numbers = ["fixed_decimal", "icu_decimal", "fixed_decimal/ryu"]
 
 [dependencies]
-bevy = { version = "0.15.0-rc.3", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
   "bevy_ui",
   "bevy_asset",
   "bevy_text",
@@ -32,7 +32,7 @@ fixed_decimal = { version = "0.5.6", optional = true }
 icu_decimal = { version = "1.5.0", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc.3" }
+bevy = { version = "0.15" }
 rust-i18n = "3"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ fn change_locale(mut i18n: ResMut<I18n>) {
 
 | bevy | bevy_simple_i18n |
 | ---- | ---------------- |
-| main | 0.1              |
+| 0.15 | 0.1              |
 
 ## Credits
 


### PR DESCRIPTION
Swap Bevy 0.15.0-rc3 to 0.15 in dependencies now that it's fully released.