### PR TITLE
Text2d support

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -1,5 +1,6 @@
 {
   "_version": 1,
   "hello": "Hello World",
+  "text2d": "Hello World (Text2d)",
   "messages.hello": "Hello %{name}"
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -54,4 +54,20 @@ fn setup(mut commands: Commands) {
                 I18nFont::new("NotoSans"),
             ));
         });
+
+        // Basic usage of the Text2d implementation
+        commands.spawn((
+            // I18nText2d component with key "text2d"
+            I18nText2d::new("text2d"),
+            // Dynamic font component with font family "NotoSans" that auto loads font files based on the set locale
+            I18nFont::new("NotoSans"),
+            // You can still insert a TextFont component though
+            // Keep in mind that the "font" field will be overridden by the I18nFont component
+            TextFont {
+                font_size: 40.0,
+                ..default()
+            },
+            // Since we're using Text2d, we add a Transform to set its position
+            Transform::from_xyz(300., 300., 0.)
+        ));
 }

--- a/src/components/i18n_font.rs
+++ b/src/components/i18n_font.rs
@@ -8,7 +8,10 @@ use bevy::{
     text::TextFont,
 };
 
-use crate::{components::I18nNumber, resources::*};
+use crate::{
+    components::{i18n_text_2d::I18nText2d, I18nNumber},
+    resources::*,
+};
 
 use super::I18nText;
 
@@ -45,6 +48,8 @@ impl Component for I18nFont {
                 i18n_text.locale.clone()
             } else if let Some(i18n_number) = world.get::<I18nNumber>(entity) {
                 i18n_number.locale.clone()
+            } else if let Some(i18n_text_2d) = world.get::<I18nText2d>(entity) {
+                i18n_text_2d.locale.clone()
             } else {
                 None
             };

--- a/src/components/i18n_text_2d.rs
+++ b/src/components/i18n_text_2d.rs
@@ -1,20 +1,16 @@
+use super::InterpolationType;
 use bevy::{
-    ecs::{
-        component::{Component, ComponentHooks, StorageType},
-        reflect::ReflectComponent,
-    },
+    ecs::component::{Component, ComponentHooks, StorageType},
     log::debug,
+    prelude::ReflectComponent,
     reflect::Reflect,
-    ui::widget::Text,
+    text::Text2d,
 };
 use rust_i18n::t;
 
-#[cfg(feature = "numbers")]
-use fixed_decimal::FixedDecimal;
-
-/// Component for spawning translatable text entities that are managed by `bevy_simple_i18n`
+/// Component for spawning translatable text 2d entities that are managed by `bevy_simple_i18n`
 ///
-/// It automatically inserts (or replaces) a Bevy `Text` component with the translated text using the provided key
+/// It automatically inserts (or replaces) a Bevy [Text2d] component with the translated text using the provided key
 ///
 /// Updates automatically whenever the locale is changed using the [crate::resources::I18n] resource
 ///
@@ -30,19 +26,19 @@ use fixed_decimal::FixedDecimal;
 ///
 /// ```
 /// // Basic usage
-/// world.spawn(I18nText::new("hello"));
+/// world.spawn(I18nText2d::new("hello"));
 ///
 /// // With interpolation arguments
-/// world.spawn(I18nText::new("greet").with_arg("name", "Bevy User"));
+/// world.spawn(I18nText2d::new("greet").with_arg("name", "Bevy User"));
 ///
 /// // With forced locale
 /// // overrides the global
 /// // does not update when the locale is changed
-/// world.spawn(I18nText::new("hello").with_locale("ja"));
+/// world.spawn(I18nText2d::new("hello").with_locale("ja"));
 /// ```
 #[derive(Default, Reflect, Debug, Clone)]
 #[reflect(Component)]
-pub struct I18nText {
+pub struct I18nText2d {
     /// Translation key for i18n
     key: String,
     /// Interpolation arguments for the translation key
@@ -51,8 +47,8 @@ pub struct I18nText {
     pub(crate) locale: Option<String>,
 }
 
-impl I18nText {
-    /// Creates a new `I18nText` component with the provided translation key
+impl I18nText2d {
+    /// Creates a new [I18nText2d] component with the provided translation key
     pub fn new(str: impl Into<String>) -> Self {
         Self {
             key: str.into(),
@@ -116,28 +112,21 @@ impl I18nText {
     }
 }
 
-impl Component for I18nText {
+impl Component for I18nText2d {
     const STORAGE_TYPE: StorageType = StorageType::Table;
 
     fn register_component_hooks(_hooks: &mut ComponentHooks) {
         _hooks.on_add(|mut world, entity, _| {
             let val = world.get::<Self>(entity).unwrap().clone();
             debug!("Adding i18n text: {}", val.key);
-            if let Some(mut text) = world.get_mut::<Text>(entity) {
+            if let Some(mut text) = world.get_mut::<Text2d>(entity) {
                 **text = val.translate();
             } else {
                 world
                     .commands()
                     .entity(entity)
-                    .insert(Text::new(val.translate()));
+                    .insert(Text2d::new(val.translate()));
             }
         });
     }
-}
-
-#[derive(Reflect, Debug, Clone)]
-pub(crate)  enum InterpolationType {
-    String(String),
-    #[cfg(feature = "numbers")]
-    Number(#[reflect(ignore)] FixedDecimal),
 }

--- a/src/components/i18n_text_2d.rs
+++ b/src/components/i18n_text_2d.rs
@@ -118,7 +118,7 @@ impl Component for I18nText2d {
     fn register_component_hooks(_hooks: &mut ComponentHooks) {
         _hooks.on_add(|mut world, entity, _| {
             let val = world.get::<Self>(entity).unwrap().clone();
-            debug!("Adding i18n text: {}", val.key);
+            debug!("Adding i18n text 2d: {}", val.key);
             if let Some(mut text) = world.get_mut::<Text2d>(entity) {
                 **text = val.translate();
             } else {

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,9 +2,11 @@ mod i18n_font;
 #[cfg(feature = "numbers")]
 mod i18n_number;
 mod i18n_text;
+mod i18n_text_2d;
 mod utils;
 
 pub use i18n_font::*;
 #[cfg(feature = "numbers")]
 pub use i18n_number::*;
 pub use i18n_text::*;
+pub use i18n_text_2d::*;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -17,6 +17,7 @@ use bevy::{
 
 use crate::{
     components::{I18nFont, I18nNumber, I18nText},
+    prelude::I18nText2d,
     resources::{FontFolder, FontManager, FontsLoading, I18n},
 };
 
@@ -47,8 +48,10 @@ impl Plugin for I18nPlugin {
                 Update,
                 (
                     monitor_font_loading.run_if(resource_exists::<FontsLoading>),
-                    update_translations.run_if(resource_removed::<FontsLoading>),
-                    update_translations.run_if(resource_changed::<I18n>),
+                    update_text_translations.run_if(resource_removed::<FontsLoading>),
+                    update_text_translations.run_if(resource_changed::<I18n>),
+                    update_text_2d_translations.run_if(resource_removed::<FontsLoading>),
+                    update_text_2d_translations.run_if(resource_changed::<I18n>),
                 ),
             );
     }
@@ -97,7 +100,7 @@ fn monitor_font_loading(
 
 /// Auto updates the translations for the text entities that have the [I18nText] component
 /// whenever the [I18n] resource changes
-fn update_translations(
+fn update_text_translations(
     font_manager: bevy::ecs::system::Res<FontManager>,
     mut text_query: Query<
         (&mut Text, &mut TextFont, Option<&I18nFont>, &I18nText),
@@ -106,6 +109,34 @@ fn update_translations(
     mut num_query: Query<
         (&mut Text, &mut TextFont, Option<&I18nFont>, &I18nNumber),
         Without<I18nText>,
+    >,
+) {
+    bevy::log::debug!("Updating translations");
+    for (mut text, mut text_font, dyn_font, key) in text_query.iter_mut() {
+        text.0 = key.translate();
+        if let Some(dyn_font) = dyn_font {
+            text_font.font = font_manager.get(&dyn_font.0, key.locale.clone());
+        }
+    }
+    for (mut text, mut text_font, dyn_font, key) in num_query.iter_mut() {
+        text.0 = key.translate();
+        if let Some(dyn_font) = dyn_font {
+            text_font.font = font_manager.get(&dyn_font.0, key.locale.clone());
+        }
+    }
+}
+
+/// Auto updates the translations for the text entities that have the [I18nText2d] component
+/// whenever the [I18n] resource changes
+fn update_text_2d_translations(
+    font_manager: bevy::ecs::system::Res<FontManager>,
+    mut text_query: Query<
+        (&mut Text, &mut TextFont, Option<&I18nFont>, &I18nText2d),
+        Without<I18nNumber>,
+    >,
+    mut num_query: Query<
+        (&mut Text, &mut TextFont, Option<&I18nFont>, &I18nNumber),
+        Without<I18nText2d>,
     >,
 ) {
     bevy::log::debug!("Updating translations");


### PR DESCRIPTION
I took the easiest route to add support for this. I believe there is a better design using Traits, that may even open up the path for third party extensions. For example, if someone were to develop their own method for rendering text with their own custom component, it would be nice if they could still take advantage of some of the automation this crate does. That of course should be its own PR. I may tackle that later if you think its worth pursuing. 

The only thing required now is a review of the changes and some basic tests to make sure everything works correctly. I will be using this myself so I may run into problems later anyway.