### PR TITLE
fix: asset folder parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fn setup(mut commands: Commands) {
 
 ## File Structure
 
-In order to use this plugin you'll need to set up your asset folder in the following way:
+In order to use this plugin, the following folder structure is recommended:
 
 ```ts
 .
@@ -66,7 +66,7 @@ In order to use this plugin you'll need to set up your asset folder in the follo
 
 ## Locale Files
 
-Locale files are stored in the `assets/locales` directory. Since we're just using the `rust-i18n` library, the format is the same. You can find more information on the supported formats [here](https://github.com/longbridgeapp/rust-i18n?tab=readme-ov-file#locale-file).
+Locale files can technically be put anywhere in your `assets` folder and this crate should find them. Since we're just using the `rust-i18n` library, the format is the same. You can find more information on the supported formats [here](https://github.com/longbridgeapp/rust-i18n?tab=readme-ov-file#locale-file).
 
 ## Features
 

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,8 @@ fn main() {
 
     let mut files = Vec::new();
 
+    let mut marker_file = File::create(Path::new(&out_dir).join(OUTPUT_FILE_NAME)).unwrap();
+
     // Check if env variable is set for the assets folder
     if let Some(dir) = env::var(ASSET_PATH_VAR)
         .ok()
@@ -68,6 +70,18 @@ fn main() {
     {
         cargo_emit::rerun_if_changed!(dir.to_string_lossy());
         // cargo_emit::warning!("Asset folder found: {}", dir.to_string_lossy());
+
+        marker_file
+            .write_all(
+                format!(
+                    r#"rust_i18n::i18n!("{}");
+
+"#,
+                    dir.to_string_lossy().replace('\\', "/"),
+                )
+                .as_bytes(),
+            )
+            .unwrap();
 
         let building_for_wasm = std::env::var("CARGO_CFG_TARGET_ARCH") == Ok("wasm32".to_string());
 
@@ -136,7 +150,6 @@ fn main() {
             });
         }
     }
-    let mut marker_file = File::create(Path::new(&out_dir).join(OUTPUT_FILE_NAME)).unwrap();
 
     marker_file
         .write_all(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ mod components;
 mod plugin;
 mod resources;
 
-rust_i18n::i18n!("assets/locales");
+include!(concat!(env!("OUT_DIR"), "/bevy_simple_i18n.rs"));
 
 pub mod prelude {
     pub use crate::components::*;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -18,9 +18,8 @@ use bevy::{
 use crate::{
     components::{I18nFont, I18nNumber, I18nText},
     resources::{FontFolder, FontManager, FontsLoading, I18n},
+    FONT_FAMILIES,
 };
-
-include!(concat!(env!("OUT_DIR"), "/bevy_simple_i18n.rs"));
 
 /// Initializes the `bevy_simple_i18n` plugin
 ///


### PR DESCRIPTION
Fixes a critical bug found by @peepo-juice that prevented this crate from parsing an asset folder outside of the crate's own directories. Also provides a lot more flexibility going forward since we're now dynamically parsing the Bevy assets folder for locale files.