### PR TITLE
refactor: use traits to dry up code, simplify adding custom components

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,6 @@ name: Publish to crates.io
 
 on:
   push:
-    branches: [main]
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ fn change_locale(mut i18n: ResMut<I18n>) {
 }
 ```
 
+## Traits
+
+### `I18nComponent`
+
+Implementing this trait for your component makes it eligible to register it and enable automatic re-translations. See [Example Implementation](./src/components/i18n_number.rs) for an example.
+
+### `I18nComponentRegistration`
+
+This trait enables the `register_i18n_component` method on your Bevy App. Registering your components with this method will allow the plugin to automatically update the components when the locale is changed, requires your component to implement the `I18nComponent` trait. Unfortunately, this does not work with the Dynamic Font feature yet.
+
+```rust
+  app.register_i18n_component::<I18nText>();
+```
+
 ## Bevy support table
 
 | bevy | bevy_simple_i18n |

--- a/src/components/i18n_font.rs
+++ b/src/components/i18n_font.rs
@@ -9,11 +9,10 @@ use bevy::{
 };
 
 use crate::{
-    components::{i18n_text_2d::I18nText2d, I18nNumber},
+    components::{I18nNumber, I18nText, I18nText2d},
+    prelude::I18nComponent,
     resources::*,
 };
-
-use super::I18nText;
 
 /// Component for spawning dynamic font entities that are managed by `bevy_simple_i18n`
 ///
@@ -44,14 +43,15 @@ impl Component for I18nFont {
                 .get_resource::<FontManager>()
                 .expect("Font manager has not been initialized");
 
+            // let x = world.query(state)
             let locale = if let Some(i18n_text) = world.get::<I18nText>(entity) {
-                i18n_text.locale.clone()
+                i18n_text.locale()
             } else if let Some(i18n_number) = world.get::<I18nNumber>(entity) {
-                i18n_number.locale.clone()
+                i18n_number.locale()
             } else if let Some(i18n_text_2d) = world.get::<I18nText2d>(entity) {
-                i18n_text_2d.locale.clone()
+                i18n_text_2d.locale()
             } else {
-                None
+                rust_i18n::locale().to_string()
             };
 
             let val = world.get::<Self>(entity).unwrap().clone();

--- a/src/components/i18n_font.rs
+++ b/src/components/i18n_font.rs
@@ -43,7 +43,6 @@ impl Component for I18nFont {
                 .get_resource::<FontManager>()
                 .expect("Font manager has not been initialized");
 
-            // let x = world.query(state)
             let locale = if let Some(i18n_text) = world.get::<I18nText>(entity) {
                 i18n_text.locale()
             } else if let Some(i18n_number) = world.get::<I18nNumber>(entity) {

--- a/src/components/i18n_number.rs
+++ b/src/components/i18n_number.rs
@@ -9,7 +9,7 @@ use bevy::{
 };
 use fixed_decimal::FixedDecimal;
 
-use super::utils;
+use super::{utils, I18nComponent};
 
 /// Component for spawning translatable number entities that are managed by `bevy_simple_i18n`
 ///
@@ -37,6 +37,19 @@ pub struct I18nNumber {
     pub(crate) locale: Option<String>,
 }
 
+impl I18nComponent for I18nNumber {
+    fn locale(&self) -> String {
+        self.locale
+            .clone()
+            .unwrap_or(rust_i18n::locale().to_string())
+    }
+
+    fn translate(&self) -> String {
+        utils::get_formatter(&self.locale(), &self.fixed_decimal)
+            .format_to_string(&self.fixed_decimal)
+    }
+}
+
 impl I18nNumber {
     /// Creates a new `I18nNumber` component with the provided number value
     pub fn new(number: impl Into<f64>) -> Self {
@@ -50,11 +63,6 @@ impl I18nNumber {
     pub fn with_locale(mut self, locale: impl Into<String>) -> Self {
         self.locale = Some(locale.into());
         self
-    }
-
-    pub(crate) fn translate(&self) -> String {
-        utils::get_formatter(&self.locale, &self.fixed_decimal)
-            .format_to_string(&self.fixed_decimal)
     }
 }
 

--- a/src/components/i18n_text.rs
+++ b/src/components/i18n_text.rs
@@ -7,10 +7,12 @@ use bevy::{
     reflect::Reflect,
     ui::widget::Text,
 };
-use rust_i18n::t;
 
 #[cfg(feature = "numbers")]
 use fixed_decimal::FixedDecimal;
+use rust_i18n::t;
+
+use super::I18nComponent;
 
 /// Component for spawning translatable text entities that are managed by `bevy_simple_i18n`
 ///
@@ -51,6 +53,38 @@ pub struct I18nText {
     pub(crate) locale: Option<String>,
 }
 
+impl I18nComponent for I18nText {
+    fn locale(&self) -> String {
+        self.locale
+            .clone()
+            .unwrap_or(rust_i18n::locale().to_string())
+    }
+
+    fn translate(&self) -> String {
+        let locale = self.locale();
+
+        #[cfg(feature = "numbers")]
+        let fdf = super::utils::get_formatter(&locale, &self.key);
+
+        let (patterns, values): (Vec<&str>, Vec<String>) = self
+            .args
+            .iter()
+            .map(|(k, interpolation_type)| {
+                let value = match interpolation_type {
+                    InterpolationType::String(v) => v.clone(),
+                    #[cfg(feature = "numbers")]
+                    InterpolationType::Number(v) => fdf.format_to_string(&v),
+                };
+                (k.as_str(), value)
+            })
+            .unzip();
+        let translated = t!(&self.key, locale = locale);
+
+        let val = rust_i18n::replace_patterns(&translated, patterns.as_slice(), values.as_slice());
+        val
+    }
+}
+
 impl I18nText {
     /// Creates a new `I18nText` component with the provided translation key
     pub fn new(str: impl Into<String>) -> Self {
@@ -87,33 +121,6 @@ impl I18nText {
         ));
         self
     }
-
-    /// Internal method that wraps the `rust_i18n::t!` macro
-    pub(crate) fn translate(&self) -> String {
-        #[cfg(feature = "numbers")]
-        let fdf = super::utils::get_formatter(&self.locale, &self.key);
-
-        let (patterns, values): (Vec<&str>, Vec<String>) = self
-            .args
-            .iter()
-            .map(|(k, interpolation_type)| {
-                let value = match interpolation_type {
-                    InterpolationType::String(v) => v.clone(),
-                    #[cfg(feature = "numbers")]
-                    InterpolationType::Number(v) => fdf.format_to_string(v),
-                };
-                (k.as_str(), value)
-            })
-            .unzip();
-        let translated = if let Some(locale) = self.locale.as_ref() {
-            t!(&self.key, locale = locale)
-        } else {
-            t!(&self.key)
-        };
-
-        let val = rust_i18n::replace_patterns(&translated, patterns.as_slice(), values.as_slice());
-        val
-    }
 }
 
 impl Component for I18nText {
@@ -136,7 +143,7 @@ impl Component for I18nText {
 }
 
 #[derive(Reflect, Debug, Clone)]
-pub(crate)  enum InterpolationType {
+pub(crate) enum InterpolationType {
     String(String),
     #[cfg(feature = "numbers")]
     Number(#[reflect(ignore)] FixedDecimal),

--- a/src/components/i18n_text.rs
+++ b/src/components/i18n_text.rs
@@ -10,9 +10,8 @@ use bevy::{
 
 #[cfg(feature = "numbers")]
 use fixed_decimal::FixedDecimal;
-use rust_i18n::t;
 
-use super::I18nComponent;
+use super::{utils::translate_by_key, I18nComponent};
 
 /// Component for spawning translatable text entities that are managed by `bevy_simple_i18n`
 ///
@@ -61,27 +60,7 @@ impl I18nComponent for I18nText {
     }
 
     fn translate(&self) -> String {
-        let locale = self.locale();
-
-        #[cfg(feature = "numbers")]
-        let fdf = super::utils::get_formatter(&locale, &self.key);
-
-        let (patterns, values): (Vec<&str>, Vec<String>) = self
-            .args
-            .iter()
-            .map(|(k, interpolation_type)| {
-                let value = match interpolation_type {
-                    InterpolationType::String(v) => v.clone(),
-                    #[cfg(feature = "numbers")]
-                    InterpolationType::Number(v) => fdf.format_to_string(&v),
-                };
-                (k.as_str(), value)
-            })
-            .unzip();
-        let translated = t!(&self.key, locale = locale);
-
-        let val = rust_i18n::replace_patterns(&translated, patterns.as_slice(), values.as_slice());
-        val
+        translate_by_key(&self.locale(), &self.key, &self.args)
     }
 }
 

--- a/src/components/i18n_text_2d.rs
+++ b/src/components/i18n_text_2d.rs
@@ -7,9 +7,8 @@ use bevy::{
     reflect::Reflect,
     text::Text2d,
 };
-use rust_i18n::t;
 
-use super::{I18nComponent, InterpolationType};
+use super::{utils::translate_by_key, I18nComponent, InterpolationType};
 
 /// Component for spawning translatable text 2d entities that are managed by `bevy_simple_i18n`
 ///
@@ -58,27 +57,7 @@ impl I18nComponent for I18nText2d {
     }
 
     fn translate(&self) -> String {
-        let locale = self.locale();
-
-        #[cfg(feature = "numbers")]
-        let fdf = super::utils::get_formatter(&locale, &self.key);
-
-        let (patterns, values): (Vec<&str>, Vec<String>) = self
-            .args
-            .iter()
-            .map(|(k, interpolation_type)| {
-                let value = match interpolation_type {
-                    InterpolationType::String(v) => v.clone(),
-                    #[cfg(feature = "numbers")]
-                    InterpolationType::Number(v) => fdf.format_to_string(v),
-                };
-                (k.as_str(), value)
-            })
-            .unzip();
-        let translated = t!(&self.key, locale = locale);
-
-        let val = rust_i18n::replace_patterns(&translated, patterns.as_slice(), values.as_slice());
-        val
+        translate_by_key(&self.locale(), &self.key, &self.args)
     }
 }
 

--- a/src/components/i18n_text_2d.rs
+++ b/src/components/i18n_text_2d.rs
@@ -9,7 +9,7 @@ use bevy::{
 };
 use rust_i18n::t;
 
-use super::InterpolationType;
+use super::{I18nComponent, InterpolationType};
 
 /// Component for spawning translatable text 2d entities that are managed by `bevy_simple_i18n`
 ///
@@ -50,6 +50,38 @@ pub struct I18nText2d {
     pub(crate) locale: Option<String>,
 }
 
+impl I18nComponent for I18nText2d {
+    fn locale(&self) -> String {
+        self.locale
+            .clone()
+            .unwrap_or(rust_i18n::locale().to_string())
+    }
+
+    fn translate(&self) -> String {
+        let locale = self.locale();
+
+        #[cfg(feature = "numbers")]
+        let fdf = super::utils::get_formatter(&locale, &self.key);
+
+        let (patterns, values): (Vec<&str>, Vec<String>) = self
+            .args
+            .iter()
+            .map(|(k, interpolation_type)| {
+                let value = match interpolation_type {
+                    InterpolationType::String(v) => v.clone(),
+                    #[cfg(feature = "numbers")]
+                    InterpolationType::Number(v) => fdf.format_to_string(v),
+                };
+                (k.as_str(), value)
+            })
+            .unzip();
+        let translated = t!(&self.key, locale = locale);
+
+        let val = rust_i18n::replace_patterns(&translated, patterns.as_slice(), values.as_slice());
+        val
+    }
+}
+
 impl I18nText2d {
     /// Creates a new [I18nText2d] component with the provided translation key
     pub fn new(str: impl Into<String>) -> Self {
@@ -85,33 +117,6 @@ impl I18nText2d {
             InterpolationType::Number(super::utils::f64_to_fd(value.into())),
         ));
         self
-    }
-
-    /// Internal method that wraps the `rust_i18n::t!` macro
-    pub(crate) fn translate(&self) -> String {
-        #[cfg(feature = "numbers")]
-        let fdf = super::utils::get_formatter(&self.locale, &self.key);
-
-        let (patterns, values): (Vec<&str>, Vec<String>) = self
-            .args
-            .iter()
-            .map(|(k, interpolation_type)| {
-                let value = match interpolation_type {
-                    InterpolationType::String(v) => v.clone(),
-                    #[cfg(feature = "numbers")]
-                    InterpolationType::Number(v) => fdf.format_to_string(v),
-                };
-                (k.as_str(), value)
-            })
-            .unzip();
-        let translated = if let Some(locale) = self.locale.as_ref() {
-            t!(&self.key, locale = locale)
-        } else {
-            t!(&self.key)
-        };
-
-        let val = rust_i18n::replace_patterns(&translated, patterns.as_slice(), values.as_slice());
-        val
     }
 }
 

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -10,3 +10,11 @@ pub use i18n_font::*;
 pub use i18n_number::*;
 pub use i18n_text::*;
 pub use i18n_text_2d::*;
+
+pub trait I18nComponent {
+    /// If set, returns the locale of the component, otherwise the global locale
+    fn locale(&self) -> String;
+
+    /// Internal method that wraps the `rust_i18n::t!` macro
+    fn translate(&self) -> String;
+}

--- a/src/components/utils.rs
+++ b/src/components/utils.rs
@@ -1,3 +1,7 @@
+use rust_i18n::t;
+
+use super::InterpolationType;
+
 #[cfg(feature = "numbers")]
 pub(super) fn f64_to_fd(value: f64) -> fixed_decimal::FixedDecimal {
     fixed_decimal::FixedDecimal::try_from_f64(value, fixed_decimal::FloatPrecision::Floating)
@@ -26,4 +30,31 @@ pub(super) fn get_formatter(
         )
         .as_str(),
     )
+}
+
+pub(super) fn translate_by_key(
+    locale: &String,
+    key: &String,
+    args: &Vec<(String, InterpolationType)>,
+) -> String {
+    let key = key.as_str();
+
+    #[cfg(feature = "numbers")]
+    let fdf = super::utils::get_formatter(locale, key);
+
+    let (patterns, values): (Vec<&str>, Vec<String>) = args
+        .iter()
+        .map(|(k, interpolation_type)| {
+            let value = match interpolation_type {
+                InterpolationType::String(v) => v.clone(),
+                #[cfg(feature = "numbers")]
+                InterpolationType::Number(v) => fdf.format_to_string(v),
+            };
+            (k.as_str(), value)
+        })
+        .unzip();
+    let translated = t!(key, locale = locale);
+
+    let val = rust_i18n::replace_patterns(&translated, patterns.as_slice(), values.as_slice());
+    val
 }

--- a/src/components/utils.rs
+++ b/src/components/utils.rs
@@ -5,24 +5,15 @@ pub(super) fn f64_to_fd(value: f64) -> fixed_decimal::FixedDecimal {
 }
 
 #[cfg(feature = "numbers")]
-pub(super) fn resolve_locale(locale: &Option<String>, label: impl ToString) -> icu_locid::Locale {
-    let string_locale = locale
-        .clone()
-        .unwrap_or_else(|| rust_i18n::locale().to_string());
-
-    string_locale.parse().expect(
-        format!(
-            "Invalid locale: {} for key: {}",
-            string_locale,
-            label.to_string()
-        )
-        .as_str(),
-    )
+pub(super) fn resolve_locale(locale: &String, label: impl ToString) -> icu_locid::Locale {
+    locale
+        .parse()
+        .expect(format!("Invalid locale: {} for key: {}", locale, label.to_string()).as_str())
 }
 
 #[cfg(feature = "numbers")]
 pub(super) fn get_formatter(
-    locale: &Option<String>,
+    locale: &String,
     label: impl ToString,
 ) -> icu_decimal::FixedDecimalFormatter {
     let label_string = label.to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,6 @@ include!(concat!(env!("OUT_DIR"), "/bevy_simple_i18n.rs"));
 
 pub mod prelude {
     pub use crate::components::*;
-    pub use crate::plugin::I18nPlugin;
+    pub use crate::plugin::*;
     pub use crate::resources::*;
 }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -110,8 +110,7 @@ impl FontManager {
         self.fonts.insert(family, font_folder);
     }
 
-    pub(crate) fn get(&self, family: &str, locale: Option<String>) -> Handle<Font> {
-        let locale = locale.unwrap_or(rust_i18n::locale().to_string());
+    pub(crate) fn get(&self, family: &str, locale: String) -> Handle<Font> {
         if let Some(folder) = self.fonts.get(family) {
             bevy::log::debug!("Found font family: {}", family);
             folder.get(locale)


### PR DESCRIPTION

## Traits

### `I18nComponent`

Implementing this trait for your component makes it eligible to register it and enable automatic re-translations. 

### `I18nComponentRegistration`

This trait enables the `register_i18n_component` method on your Bevy App. Registering your components with this method will allow the plugin to automatically update the components when the locale is changed, requires your component to implement the `I18nComponent` trait. Unfortunately, this does not fully work with the Dynamic Font feature yet.

```rust
  app.register_i18n_component::<I18nText>();
```
