### PR TITLE
Update to Bevy 0.19 + idiomatic modernization (fixes #6, #7)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "bevy-web",
+      "runtimeExecutable": "sh",
+      "runtimeArgs": [
+        "-lc",
+        "cd web && exec \"$HOME/.cargo/bin/trunk\" serve --port 8180 --address 127.0.0.1"
+      ],
+      "port": 8180
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux dependencies
-        run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+        run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libwayland-dev libxkbcommon-dev
 
       - name: Run cargo check
         run: cargo check --all-targets
@@ -38,7 +38,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux dependencies
-        run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+        run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libwayland-dev libxkbcommon-dev
 
       - name: Run cargo doc
         run: cargo doc --no-deps
@@ -54,7 +54,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Linux dependencies
-        run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+        run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libwayland-dev libxkbcommon-dev
 
       - name: Build examples
         run: cargo build --examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - Unreleased
+
+### Changed
+
+- **Updated to Bevy 0.19.** This is the headline change and is a breaking upgrade; see the
+  [Bevy 0.16](https://bevy.org/learn/migration-guides/0-15-to-0-16/),
+  [0.17](https://bevy.org/learn/migration-guides/0-16-to-0-17/),
+  [0.18](https://bevy.org/learn/migration-guides/0-17-to-0-18/) and
+  [0.19](https://bevy.org/learn/migration-guides/0-18-to-0-19/) migration guides for engine-level
+  details.
+- Bevy 0.19 reworked the text API: `TextFont::font` is now a `FontSource` enum (a `Handle<Font>`
+  converts via `.into()`) and `TextFont::font_size` is now a `FontSize` enum (`FontSize::Px(..)`).
+- The four built-in components (`I18nText`, `I18nText2d`, `I18nNumber`, `I18nFont`) are now plain
+  `#[derive(Component)]` types that use the `#[require(..)]` attribute to insert their target text
+  component, instead of hand-written `Component` implementations with `on_add` hooks.
+- Translation updates are now handled by a single change-detection system per component type
+  (using `Ref<T>` + resource change detection) instead of component hooks plus locale-change
+  systems. Initial spawn and locale changes flow through the same code path.
+- The `I18nComponent` trait now has a `Component` supertrait and an associated
+  `type Target: Component<Mutability = Mutable> + DerefMut<Target = String>` describing which text
+  component it drives.
+- Reflect types (`I18n`, `I18nText`, `I18nText2d`, `I18nNumber`, `I18nFont`) are now registered
+  with the type registry by the plugin.
+
+### Fixed
+
+- **`I18nText2d` now re-translates when the locale changes.** The shared update system previously
+  queried `&mut Text` for every registered component, so `Text2d`-backed entities were never
+  updated after their initial spawn.
+- **The crate now compiles even when no `assets` folder is found.** The build script always emits a
+  `rust_i18n::i18n!(..)` invocation (falling back to `"locales"`), so the `t!` macro always has a
+  backend to expand into. ([#6](https://github.com/TurtIeSocks/bevy_simple_i18n/issues/6))
+- Asset/font paths emitted by the build script are now always forward-slashed for consistent
+  resolution across platforms (including wasm).
+- The build script's "asset folder not found" message is now a clear, actionable warning that
+  points at `BEVY_ASSET_PATH`.
+
+### Removed
+
+- The internal `FontsLoading` resource and `monitor_font_loading` system. Text now renders
+  immediately and fonts stream in asynchronously like any other Bevy asset.
+
+### Docs
+
+- Documented `BEVY_ASSET_PATH` and workspace-project setup in the README.
+  ([#6](https://github.com/TurtIeSocks/bevy_simple_i18n/issues/6))
+
+### Notes for maintainer
+
+- This release should be published to crates.io; the currently published `0.1.2` predates the
+  build-script fixes and does not translate in many setups.
+  ([#7](https://github.com/TurtIeSocks/bevy_simple_i18n/issues/7))
+
+## [0.1.x]
+
+- Initial releases targeting Bevy 0.15.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_simple_i18n"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["TurtIeSocks"]
 license = "MIT OR Apache-2.0"
@@ -20,10 +20,12 @@ default = ["numbers"]
 numbers = ["fixed_decimal", "icu_decimal", "fixed_decimal/ryu"]
 
 [dependencies]
-bevy = { version = "0.15", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
   "bevy_ui",
   "bevy_asset",
   "bevy_text",
+  "bevy_sprite", # provides Text2d (moved out of bevy_text in 0.17)
+  "bevy_log",
 ] }
 icu_locid = "1.5.0"
 rust-i18n = "3"
@@ -32,7 +34,7 @@ fixed_decimal = { version = "0.5.6", optional = true }
 icu_decimal = { version = "1.5.0", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15" }
+bevy = { version = "0.19" }
 rust-i18n = "3"
 
 [build-dependencies]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2d::default());
+    commands.spawn(Camera2d);
     commands.spawn((I18nText::new("hello"), I18nFont::new("NotoSans")));
     commands.spawn((I18nNumber::new(2503.10), I18nFont::new("NotoSans")));
 }
@@ -67,6 +67,25 @@ In order to use this plugin, the following folder structure is recommended:
 ## Locale Files
 
 Locale files can technically be put anywhere in your `assets` folder and this crate should find them. Since we're just using the `rust-i18n` library, the format is the same. You can find more information on the supported formats [here](https://github.com/longbridgeapp/rust-i18n?tab=readme-ov-file#locale-file).
+
+## Asset Path & Workspace Projects
+
+This crate's build script embeds your locales (and discovers dynamic fonts) at compile time. To do so it has to locate your `assets` folder. By default it walks up from the build output directory to the cargo `target` directory and uses the sibling `assets` folder, which is correct for most single-crate projects.
+
+In a **workspace-structured project**, the build script cannot know which member crate's `assets` folder Bevy will actually load at runtime. Set the `BEVY_ASSET_PATH` environment variable to the absolute (or workspace-relative) path of the `assets` directory you load at runtime:
+
+```sh
+# one-off
+BEVY_ASSET_PATH=./crates/my_game/assets cargo run -p my_game
+```
+
+```toml
+# or persist it for the whole workspace in .cargo/config.toml
+[env]
+BEVY_ASSET_PATH = { value = "crates/my_game/assets", relative = true }
+```
+
+Make sure this is the same folder Bevy resolves at runtime — if you customize `AssetPlugin { file_path, .. }`, point `BEVY_ASSET_PATH` at the matching directory. If no assets folder is found the crate still compiles (translations and fonts are simply empty) and emits a build warning.
 
 ## Features
 
@@ -168,7 +187,7 @@ Implementing this trait for your component makes it eligible to register it and 
 
 ### `I18nComponentRegistration`
 
-This trait enables the `register_i18n_component` method on your Bevy App. Registering your components with this method will allow the plugin to automatically update the components when the locale is changed, requires your component to implement the `I18nComponent` trait. Unfortunately, this does not work with the Dynamic Font feature yet.
+This trait enables the `register_i18n_component` method on your Bevy App. Registering your components with this method will allow the plugin to automatically update the components when the locale is changed, requires your component to implement the `I18nComponent` trait. Registered components participate in the Dynamic Font feature too: pair them with an `I18nFont` and the font handle is kept in sync with the resolved locale.
 
 ```rust
   app.register_i18n_component::<I18nText>();
@@ -178,6 +197,7 @@ This trait enables the `register_i18n_component` method on your Bevy App. Regist
 
 | bevy | bevy_simple_i18n |
 | ---- | ---------------- |
+| 0.19 | 0.2              |
 | 0.15 | 0.1              |
 
 ## Credits

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 use std::{
     env,
+    ffi::OsStr,
     fs::{self, File},
     io::Write,
     path::{Path, PathBuf},
@@ -13,123 +14,59 @@ fn main() {
     cargo_emit::rerun_if_env_changed!(ASSET_PATH_VAR);
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
-
-    let mut files = Vec::new();
-
     let mut marker_file = File::create(Path::new(&out_dir).join(OUTPUT_FILE_NAME)).unwrap();
 
-    // Check if env variable is set for the assets folder
-    if let Some(dir) = env::var(ASSET_PATH_VAR)
-        .ok()
-        .map(|v| Path::new(&v).to_path_buf())
-        .and_then(|path| {
-            if path.exists() {
-                Some(path)
-            } else {
-                cargo_emit::warning!(
-                    "${} points to an unknown folder: {}",
-                    ASSET_PATH_VAR,
-                    path.to_string_lossy()
-                );
-                None
-            }
-        })
-        // Otherwise, search for the target folder and look for an assets folder next to it
-        .or_else(|| {
-            env::var("OUT_DIR")
-                .ok()
-                .map(|v| Path::new(&v).to_path_buf())
-                .and_then(|path| {
-                    for ancestor in path.ancestors() {
-                        if let Some(last) = ancestor.file_name() {
-                            if last == "target" {
-                                return ancestor.parent().map(|parent| {
-                                    let imported_dir = parent.join("imported_assets");
-                                    if imported_dir.exists() {
-                                        imported_dir.join("Default")
-                                    } else {
-                                        parent.join("assets")
-                                    }
-                                });
-                            }
-                        }
-                    }
-                    None
-                })
-                .and_then(|path| {
-                    if path.exists() {
-                        Some(path)
-                    } else {
-                        cargo_emit::warning!(
-                            "Could not find asset folder from Cargo build directory"
-                        );
-                        None
-                    }
-                })
-        })
-    {
+    let asset_dir = resolve_asset_dir();
+
+    // Always emit a `rust_i18n::i18n!` invocation, even when no asset folder is found. The `t!`
+    // macro used throughout the crate expands to a call into the backend this macro generates, so
+    // without it the crate fails to compile (rather than just lacking translations).
+    // See https://github.com/TurtIeSocks/bevy_simple_i18n/issues/6.
+    let i18n_path = match &asset_dir {
+        Some(dir) => dir.to_string_lossy().replace('\\', "/"),
+        None => "locales".to_string(),
+    };
+    marker_file
+        .write_all(format!("rust_i18n::i18n!({i18n_path:?});\n\n").as_bytes())
+        .unwrap();
+
+    // Collect every font file under the asset folder (if we found one).
+    let mut files = Vec::new();
+    if let Some(dir) = &asset_dir {
         cargo_emit::rerun_if_changed!(dir.to_string_lossy());
-        // cargo_emit::warning!("Asset folder found: {}", dir.to_string_lossy());
+        for full_path in visit_dirs(dir) {
+            cargo_emit::rerun_if_changed!(full_path.to_string_lossy());
+            let path = full_path.strip_prefix(dir).unwrap();
+            // Always store forward-slashed, asset-root-relative paths so the handles built at
+            // runtime resolve identically on every platform (including wasm).
+            let string_path = path
+                .to_string_lossy()
+                .replace(std::path::MAIN_SEPARATOR, "/");
 
-        marker_file
-            .write_all(
-                format!(
-                    r#"rust_i18n::i18n!("{}");
+            let Some(ext) = full_path.extension().and_then(OsStr::to_str) else {
+                continue;
+            };
+            if !ALLOWED_EXTENSIONS.contains(&ext) {
+                continue;
+            }
 
-"#,
-                    dir.to_string_lossy().replace('\\', "/"),
-                )
-                .as_bytes(),
-            )
-            .unwrap();
+            let locale = path.file_stem().unwrap().to_string_lossy().into_owned();
+            let family = path
+                .parent()
+                .unwrap()
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
 
-        let building_for_wasm = std::env::var("CARGO_CFG_TARGET_ARCH") == Ok("wasm32".to_string());
-
-        visit_dirs(&dir)
-            .iter()
-            .map(|path| (path, path.strip_prefix(&dir).unwrap()))
-            .for_each(|(full_path, path)| {
-                let mut string_path = path.to_string_lossy().to_string();
-                if building_for_wasm {
-                    // building for wasm. replace paths with forward slash in case we're building from windows
-                    string_path = string_path.replace(std::path::MAIN_SEPARATOR, "/");
-                }
-                cargo_emit::rerun_if_changed!(full_path.to_string_lossy());
-                if let Some(ext) = full_path.extension().and_then(|e| e.to_str()) {
-                    if ALLOWED_EXTENSIONS.contains(&ext) {
-                        // Extract filename without extension
-                        let locale = path.file_stem().unwrap().to_string_lossy().into_owned();
-
-                        // Extract file extension
-                        let ext = path.extension().unwrap().to_string_lossy().into_owned();
-
-                        // Extract the most immediate folder name
-                        let family = path
-                            .parent()
-                            .unwrap()
-                            .file_name()
-                            .unwrap()
-                            .to_string_lossy()
-                            .into_owned();
-
-                        files.push(FontAsset {
-                            is_fallback: locale == "fallback",
-                            path: PathBuf::from(string_path),
-                            family,
-                            locale,
-                            ext,
-                        });
-                    }
-                }
+            files.push(FontAsset {
+                is_fallback: locale == "fallback",
+                path: PathBuf::from(string_path),
+                family,
+                locale,
+                ext: ext.to_owned(),
             });
-    } else if std::env::var("DOCS_RS").is_ok() {
-        // We're building the docs, so we don't need to do anything
-    } else {
-        cargo_emit::warning!(
-            "Could not find asset folder, please specify its path with ${}",
-            ASSET_PATH_VAR
-        );
-        // panic!("No asset folder found");
+        }
     }
 
     let mut families: Vec<FontFamily> = Vec::new();
@@ -162,7 +99,7 @@ pub(crate) struct FontFamily {{
 }}
 
 {}
-pub(crate) const FONT_FAMILIES: &'static [FontFamily] = &[{}];
+pub(crate) const FONT_FAMILIES: &[FontFamily] = &[{}];
 "#,
                 families
                     .iter()
@@ -178,6 +115,65 @@ pub(crate) const FONT_FAMILIES: &'static [FontFamily] = &[{}];
             .as_bytes(),
         )
         .unwrap();
+}
+
+/// Locates the asset folder that holds the `locales` and font files.
+///
+/// Resolution order:
+/// 1. The `BEVY_ASSET_PATH` environment variable (recommended for workspace projects, where the
+///    heuristic below cannot know which crate's `assets` folder Bevy will load at runtime).
+/// 2. The `assets` (or `imported_assets/Default`) folder next to the cargo `target` directory.
+///
+/// Returns `None` when building on docs.rs or when no folder can be found.
+fn resolve_asset_dir() -> Option<PathBuf> {
+    // 1. Explicit override.
+    if let Ok(value) = env::var(ASSET_PATH_VAR) {
+        let path = PathBuf::from(&value);
+        if path.exists() {
+            return Some(path);
+        }
+        cargo_emit::warning!(
+            "${} points to an unknown folder: {}",
+            ASSET_PATH_VAR,
+            path.to_string_lossy()
+        );
+    }
+
+    // 2. Walk up from OUT_DIR to the cargo `target` directory and use the sibling assets folder.
+    let candidate = env::var_os("OUT_DIR")
+        .map(PathBuf::from)
+        .and_then(|out| {
+            out.ancestors()
+                .find(|ancestor| ancestor.file_name() == Some(OsStr::new("target")))
+                .and_then(Path::parent)
+                .map(Path::to_path_buf)
+        })
+        .map(|root| {
+            let imported = root.join("imported_assets");
+            if imported.exists() {
+                imported.join("Default")
+            } else {
+                root.join("assets")
+            }
+        });
+    if let Some(dir) = candidate {
+        if dir.exists() {
+            return Some(dir);
+        }
+    }
+
+    // We're building the docs, so an empty translation set is expected.
+    if env::var("DOCS_RS").is_ok() {
+        return None;
+    }
+
+    cargo_emit::warning!(
+        "bevy_simple_i18n could not locate an `assets` folder, so translations and dynamic fonts \
+         will be empty. Set the `{}` environment variable to your assets directory. This is \
+         required for workspace-structured projects; see the README for details.",
+        ASSET_PATH_VAR
+    );
+    None
 }
 
 struct FontAsset {
@@ -211,12 +207,12 @@ impl FontFamily {
     }
 
     fn push_const(&self) -> String {
-        format!("{}", self.snake_case().to_uppercase())
+        self.snake_case().to_uppercase()
     }
 
     fn snake_case(&self) -> String {
         let mut snake_case = String::new();
-        let name = self.folder.replace(&['/', '\\', '.', '-'][..], "_");
+        let name = self.folder.replace(['/', '\\', '.', '-'], "_");
         let mut prev_char = '\0';
         for (i, ch) in name.chars().enumerate() {
             if ch.is_uppercase() && i > 0 && prev_char != '_' {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -12,7 +12,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn(Camera2d::default());
+    commands.spawn(Camera2d);
     commands
         .spawn(Node {
             width: Val::Percent(100.),
@@ -34,7 +34,7 @@ fn setup(mut commands: Commands) {
                 // You can still insert a TextFont component though
                 // Keep in mind that the "font" field will be overridden by the I18nFont component
                 TextFont {
-                    font_size: 40.0,
+                    font_size: FontSize::Px(40.0),
                     ..default()
                 },
             ));
@@ -55,19 +55,19 @@ fn setup(mut commands: Commands) {
             ));
         });
 
-        // Basic usage of the Text2d implementation
-        commands.spawn((
-            // I18nText2d component with key "text2d"
-            I18nText2d::new("text2d"),
-            // Dynamic font component with font family "NotoSans" that auto loads font files based on the set locale
-            I18nFont::new("NotoSans"),
-            // You can still insert a TextFont component though
-            // Keep in mind that the "font" field will be overridden by the I18nFont component
-            TextFont {
-                font_size: 40.0,
-                ..default()
-            },
-            // Since we're using Text2d, we add a Transform to set its position
-            Transform::from_xyz(300., 300., 0.)
-        ));
+    // Basic usage of the Text2d implementation
+    commands.spawn((
+        // I18nText2d component with key "text2d"
+        I18nText2d::new("text2d"),
+        // Dynamic font component with font family "NotoSans" that auto loads font files based on the set locale
+        I18nFont::new("NotoSans"),
+        // You can still insert a TextFont component though
+        // Keep in mind that the "font" field will be overridden by the I18nFont component
+        TextFont {
+            font_size: FontSize::Px(40.0),
+            ..default()
+        },
+        // Since we're using Text2d, we add a Transform to set its position
+        Transform::from_xyz(300., 300., 0.),
+    ));
 }

--- a/examples/changing_locale.rs
+++ b/examples/changing_locale.rs
@@ -12,7 +12,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, i18n_res: Res<I18n>) {
-    commands.spawn(Camera2d::default());
+    commands.spawn(Camera2d);
     commands
         .spawn(Node {
             width: Val::Percent(100.),
@@ -117,16 +117,16 @@ fn setup(mut commands: Commands, i18n_res: Res<I18n>) {
                                     border: UiRect::all(Val::Px(5.0)),
                                     justify_content: JustifyContent::Center,
                                     align_items: AlignItems::Center,
+                                    border_radius: BorderRadius::MAX,
                                     ..default()
                                 },
-                                BorderColor(Color::BLACK),
-                                BorderRadius::MAX,
+                                BorderColor::all(Color::BLACK),
                                 BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
                             ))
                             .with_child((
                                 Text::new(locale),
                                 TextFont {
-                                    font_size: 50.0,
+                                    font_size: FontSize::Px(50.0),
                                     ..default()
                                 },
                                 TextColor(Color::srgb(0.9, 0.9, 0.9)),
@@ -136,18 +136,16 @@ fn setup(mut commands: Commands, i18n_res: Res<I18n>) {
         });
 }
 
+#[allow(clippy::type_complexity)]
 fn button_system(
     interaction_query: Query<(&Interaction, &Children), (Changed<Interaction>, With<Button>)>,
     text_query: Query<&Text>,
     mut i18n_res: ResMut<I18n>,
 ) {
     for (interaction, children) in interaction_query.iter() {
-        match *interaction {
-            Interaction::Pressed => {
-                let text = text_query.get(children[0]).unwrap().clone().0;
-                i18n_res.set_locale(text);
-            }
-            _ => {}
+        if *interaction == Interaction::Pressed {
+            let text = text_query.get(children[0]).unwrap().0.clone();
+            i18n_res.set_locale(text);
         }
     }
 }

--- a/src/components/i18n_font.rs
+++ b/src/components/i18n_font.rs
@@ -1,70 +1,29 @@
-use bevy::{
-    ecs::{
-        component::{Component, ComponentHooks, StorageType},
-        reflect::ReflectComponent,
-    },
-    log::debug,
-    reflect::Reflect,
-    text::TextFont,
-};
-
-use crate::{
-    components::{I18nNumber, I18nText, I18nText2d},
-    prelude::I18nComponent,
-    resources::*,
-};
+use bevy::prelude::*;
 
 /// Component for spawning dynamic font entities that are managed by `bevy_simple_i18n`
 ///
-/// The font for the text entity will be automatically updated based on the locale set by the [I18n] resource
+/// A Bevy [`TextFont`] component is inserted automatically (via `#[require(TextFont)]`) and its
+/// font handle is updated based on the locale of the sibling i18n component
+/// ([`I18nText`](crate::prelude::I18nText), [`I18nNumber`](crate::prelude::I18nNumber) or
+/// [`I18nText2d`](crate::prelude::I18nText2d)) on the same entity.
 ///
 /// # Example
 ///
 /// ```
-/// world.spawn((I18nText::new("hello"), I18nFont::new("NotoSans")));
+/// # use bevy::prelude::*;
+/// # use bevy_simple_i18n::prelude::*;
+/// # fn system(mut commands: Commands) {
+/// commands.spawn((I18nText::new("hello"), I18nFont::new("NotoSans")));
+/// # }
 /// ```
-#[derive(Default, Reflect, Debug, Clone)]
+#[derive(Component, Default, Reflect, Debug, Clone)]
 #[reflect(Component)]
+#[require(TextFont)]
 pub struct I18nFont(pub(crate) String);
 
 impl I18nFont {
     /// Creates a new `I18nFont` component from the provided font family
     pub fn new(family: impl Into<String>) -> Self {
         Self(family.into())
-    }
-}
-
-impl Component for I18nFont {
-    const STORAGE_TYPE: StorageType = StorageType::Table;
-
-    fn register_component_hooks(_hooks: &mut ComponentHooks) {
-        _hooks.on_add(|mut world, entity, _| {
-            let font_manager = world
-                .get_resource::<FontManager>()
-                .expect("Font manager has not been initialized");
-
-            let locale = if let Some(i18n_text) = world.get::<I18nText>(entity) {
-                i18n_text.locale()
-            } else if let Some(i18n_number) = world.get::<I18nNumber>(entity) {
-                i18n_number.locale()
-            } else if let Some(i18n_text_2d) = world.get::<I18nText2d>(entity) {
-                i18n_text_2d.locale()
-            } else {
-                rust_i18n::locale().to_string()
-            };
-
-            let val = world.get::<Self>(entity).unwrap().clone();
-            let font_handler = font_manager.get(&val.0, locale);
-
-            debug!("Adding dynamic font: {}", val.0);
-            if let Some(mut font) = world.get_mut::<TextFont>(entity) {
-                font.font = font_handler;
-            } else {
-                world.commands().entity(entity).insert(TextFont {
-                    font: font_handler,
-                    ..Default::default()
-                });
-            }
-        });
     }
 }

--- a/src/components/i18n_number.rs
+++ b/src/components/i18n_number.rs
@@ -1,35 +1,33 @@
-use bevy::{
-    ecs::{
-        component::{Component, ComponentHooks, StorageType},
-        reflect::ReflectComponent,
-    },
-    log::debug,
-    reflect::Reflect,
-    ui::widget::Text,
-};
+use bevy::prelude::*;
 use fixed_decimal::FixedDecimal;
 
 use super::{utils, I18nComponent};
 
 /// Component for spawning translatable number entities that are managed by `bevy_simple_i18n`
 ///
-/// It automatically inserts (or replaces) a Bevy `Text` component with the localized number
+/// A Bevy [`Text`] component is inserted automatically (via `#[require(Text)]`) and kept in sync
+/// with the localized number.
 ///
-/// Updates automatically whenever the locale is changed using the [crate::resources::I18n] resource
+/// Updates automatically whenever the locale is changed using the [`crate::resources::I18n`] resource
 ///
 /// # Example
 ///
 /// ```
+/// # use bevy::prelude::*;
+/// # use bevy_simple_i18n::prelude::*;
+/// # fn system(mut commands: Commands) {
 /// // Basic usage
-/// world.spawn(I18nNumber::new(200.40));
+/// commands.spawn(I18nNumber::new(200.40));
 ///
 /// // With forced locale
 /// // overrides the global
 /// // does not update when the locale is changed
-/// world.spawn(I18nNumber::new(12051).with_locale("ja"));
+/// commands.spawn(I18nNumber::new(12051).with_locale("ja"));
+/// # }
 /// ```
-#[derive(Default, Reflect, Debug, Clone)]
+#[derive(Component, Default, Reflect, Debug, Clone)]
 #[reflect(Component)]
+#[require(Text)]
 pub struct I18nNumber {
     #[reflect(ignore)]
     pub(crate) fixed_decimal: FixedDecimal,
@@ -38,10 +36,12 @@ pub struct I18nNumber {
 }
 
 impl I18nComponent for I18nNumber {
+    type Target = Text;
+
     fn locale(&self) -> String {
         self.locale
             .clone()
-            .unwrap_or(rust_i18n::locale().to_string())
+            .unwrap_or_else(|| rust_i18n::locale().to_string())
     }
 
     fn translate(&self) -> String {
@@ -63,24 +63,5 @@ impl I18nNumber {
     pub fn with_locale(mut self, locale: impl Into<String>) -> Self {
         self.locale = Some(locale.into());
         self
-    }
-}
-
-impl Component for I18nNumber {
-    const STORAGE_TYPE: StorageType = StorageType::Table;
-
-    fn register_component_hooks(_hooks: &mut ComponentHooks) {
-        _hooks.on_add(|mut world, entity, _| {
-            let val = world.get::<Self>(entity).unwrap().clone();
-            debug!("Adding i18n number: {}", val.fixed_decimal);
-            if let Some(mut text) = world.get_mut::<Text>(entity) {
-                **text = val.translate();
-            } else {
-                world
-                    .commands()
-                    .entity(entity)
-                    .insert(Text::new(val.translate()));
-            }
-        });
     }
 }

--- a/src/components/i18n_text.rs
+++ b/src/components/i18n_text.rs
@@ -1,12 +1,4 @@
-use bevy::{
-    ecs::{
-        component::{Component, ComponentHooks, StorageType},
-        reflect::ReflectComponent,
-    },
-    log::debug,
-    reflect::Reflect,
-    ui::widget::Text,
-};
+use bevy::prelude::*;
 
 #[cfg(feature = "numbers")]
 use fixed_decimal::FixedDecimal;
@@ -15,9 +7,10 @@ use super::{utils::translate_by_key, I18nComponent};
 
 /// Component for spawning translatable text entities that are managed by `bevy_simple_i18n`
 ///
-/// It automatically inserts (or replaces) a Bevy `Text` component with the translated text using the provided key
+/// A Bevy [`Text`] component is inserted automatically (via `#[require(Text)]`) and kept in sync
+/// with the translated value for the provided key.
 ///
-/// Updates automatically whenever the locale is changed using the [crate::resources::I18n] resource
+/// Updates automatically whenever the locale is changed using the [`crate::resources::I18n`] resource
 ///
 /// # Example
 ///
@@ -30,19 +23,24 @@ use super::{utils::translate_by_key, I18nComponent};
 /// ```
 ///
 /// ```
+/// # use bevy::prelude::*;
+/// # use bevy_simple_i18n::prelude::*;
+/// # fn system(mut commands: Commands) {
 /// // Basic usage
-/// world.spawn(I18nText::new("hello"));
+/// commands.spawn(I18nText::new("hello"));
 ///
 /// // With interpolation arguments
-/// world.spawn(I18nText::new("greet").with_arg("name", "Bevy User"));
+/// commands.spawn(I18nText::new("greet").with_arg("name", "Bevy User"));
 ///
 /// // With forced locale
 /// // overrides the global
 /// // does not update when the locale is changed
-/// world.spawn(I18nText::new("hello").with_locale("ja"));
+/// commands.spawn(I18nText::new("hello").with_locale("ja"));
+/// # }
 /// ```
-#[derive(Default, Reflect, Debug, Clone)]
+#[derive(Component, Default, Reflect, Debug, Clone)]
 #[reflect(Component)]
+#[require(Text)]
 pub struct I18nText {
     /// Translation key for i18n
     key: String,
@@ -53,10 +51,12 @@ pub struct I18nText {
 }
 
 impl I18nComponent for I18nText {
+    type Target = Text;
+
     fn locale(&self) -> String {
         self.locale
             .clone()
-            .unwrap_or(rust_i18n::locale().to_string())
+            .unwrap_or_else(|| rust_i18n::locale().to_string())
     }
 
     fn translate(&self) -> String {
@@ -99,25 +99,6 @@ impl I18nText {
             InterpolationType::Number(super::utils::f64_to_fd(value.into())),
         ));
         self
-    }
-}
-
-impl Component for I18nText {
-    const STORAGE_TYPE: StorageType = StorageType::Table;
-
-    fn register_component_hooks(_hooks: &mut ComponentHooks) {
-        _hooks.on_add(|mut world, entity, _| {
-            let val = world.get::<Self>(entity).unwrap().clone();
-            debug!("Adding i18n text: {}", val.key);
-            if let Some(mut text) = world.get_mut::<Text>(entity) {
-                **text = val.translate();
-            } else {
-                world
-                    .commands()
-                    .entity(entity)
-                    .insert(Text::new(val.translate()));
-            }
-        });
     }
 }
 

--- a/src/components/i18n_text_2d.rs
+++ b/src/components/i18n_text_2d.rs
@@ -1,20 +1,13 @@
-use bevy::{
-    ecs::{
-        component::{Component, ComponentHooks, StorageType},
-        reflect::ReflectComponent,
-    },
-    log::debug,
-    reflect::Reflect,
-    text::Text2d,
-};
+use bevy::prelude::*;
 
 use super::{utils::translate_by_key, I18nComponent, InterpolationType};
 
 /// Component for spawning translatable text 2d entities that are managed by `bevy_simple_i18n`
 ///
-/// It automatically inserts (or replaces) a Bevy [Text2d] component with the translated text using the provided key
+/// A Bevy [`Text2d`] component is inserted automatically (via `#[require(Text2d)]`) and kept in
+/// sync with the translated value for the provided key.
 ///
-/// Updates automatically whenever the locale is changed using the [crate::resources::I18n] resource
+/// Updates automatically whenever the locale is changed using the [`crate::resources::I18n`] resource
 ///
 /// # Example
 ///
@@ -27,19 +20,24 @@ use super::{utils::translate_by_key, I18nComponent, InterpolationType};
 /// ```
 ///
 /// ```
+/// # use bevy::prelude::*;
+/// # use bevy_simple_i18n::prelude::*;
+/// # fn system(mut commands: Commands) {
 /// // Basic usage
-/// world.spawn(I18nText2d::new("hello"));
+/// commands.spawn(I18nText2d::new("hello"));
 ///
 /// // With interpolation arguments
-/// world.spawn(I18nText2d::new("greet").with_arg("name", "Bevy User"));
+/// commands.spawn(I18nText2d::new("greet").with_arg("name", "Bevy User"));
 ///
 /// // With forced locale
 /// // overrides the global
 /// // does not update when the locale is changed
-/// world.spawn(I18nText2d::new("hello").with_locale("ja"));
+/// commands.spawn(I18nText2d::new("hello").with_locale("ja"));
+/// # }
 /// ```
-#[derive(Default, Reflect, Debug, Clone)]
+#[derive(Component, Default, Reflect, Debug, Clone)]
 #[reflect(Component)]
+#[require(Text2d)]
 pub struct I18nText2d {
     /// Translation key for i18n
     key: String,
@@ -50,10 +48,12 @@ pub struct I18nText2d {
 }
 
 impl I18nComponent for I18nText2d {
+    type Target = Text2d;
+
     fn locale(&self) -> String {
         self.locale
             .clone()
-            .unwrap_or(rust_i18n::locale().to_string())
+            .unwrap_or_else(|| rust_i18n::locale().to_string())
     }
 
     fn translate(&self) -> String {
@@ -62,7 +62,7 @@ impl I18nComponent for I18nText2d {
 }
 
 impl I18nText2d {
-    /// Creates a new [I18nText2d] component with the provided translation key
+    /// Creates a new [`I18nText2d`] component with the provided translation key
     pub fn new(str: impl Into<String>) -> Self {
         Self {
             key: str.into(),
@@ -96,24 +96,5 @@ impl I18nText2d {
             InterpolationType::Number(super::utils::f64_to_fd(value.into())),
         ));
         self
-    }
-}
-
-impl Component for I18nText2d {
-    const STORAGE_TYPE: StorageType = StorageType::Table;
-
-    fn register_component_hooks(_hooks: &mut ComponentHooks) {
-        _hooks.on_add(|mut world, entity, _| {
-            let val = world.get::<Self>(entity).unwrap().clone();
-            debug!("Adding i18n text 2d: {}", val.key);
-            if let Some(mut text) = world.get_mut::<Text2d>(entity) {
-                **text = val.translate();
-            } else {
-                world
-                    .commands()
-                    .entity(entity)
-                    .insert(Text2d::new(val.translate()));
-            }
-        });
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,8 @@
+use std::ops::DerefMut;
+
+use bevy::ecs::component::Mutable;
+use bevy::prelude::Component;
+
 mod i18n_font;
 #[cfg(feature = "numbers")]
 mod i18n_number;
@@ -11,10 +16,24 @@ pub use i18n_number::*;
 pub use i18n_text::*;
 pub use i18n_text_2d::*;
 
-pub trait I18nComponent {
-    /// If set, returns the locale of the component, otherwise the global locale
+/// Trait implemented by every component that `bevy_simple_i18n` keeps translated.
+///
+/// Implementing this and registering it with
+/// [`register_i18n_component`](crate::prelude::I18nComponentRegistration::register_i18n_component)
+/// lets you drive any custom text component from a translation key. The built-in
+/// [`I18nText`], [`I18nText2d`] and [`I18nNumber`] components all implement it.
+pub trait I18nComponent: Component {
+    /// The Bevy text component this writes its translated value into.
+    ///
+    /// It must dereference to a [`String`] — as Bevy's [`Text`](bevy::prelude::Text) and
+    /// [`Text2d`](bevy::prelude::Text2d) both do — and is inserted automatically via the
+    /// `#[require(..)]` attribute on the implementing component.
+    type Target: Component<Mutability = Mutable> + DerefMut<Target = String>;
+
+    /// Returns this component's locale: its per-entity override if one was set, otherwise the
+    /// global locale managed by the [`I18n`](crate::prelude::I18n) resource.
     fn locale(&self) -> String;
 
-    /// Internal method that wraps the `rust_i18n::t!` macro
+    /// Produces the translated / localized string for the resolved [`locale`](Self::locale).
     fn translate(&self) -> String;
 }

--- a/src/components/utils.rs
+++ b/src/components/utils.rs
@@ -5,42 +5,35 @@ use super::InterpolationType;
 #[cfg(feature = "numbers")]
 pub(super) fn f64_to_fd(value: f64) -> fixed_decimal::FixedDecimal {
     fixed_decimal::FixedDecimal::try_from_f64(value, fixed_decimal::FloatPrecision::Floating)
-        .expect(format!("Failed to parse FixedDecimal from f64: {}", value).as_str())
+        .unwrap_or_else(|err| panic!("Failed to parse FixedDecimal from f64 {value}: {err}"))
 }
 
 #[cfg(feature = "numbers")]
-pub(super) fn resolve_locale(locale: &String, label: impl ToString) -> icu_locid::Locale {
+pub(super) fn resolve_locale(locale: &str, label: impl std::fmt::Display) -> icu_locid::Locale {
     locale
         .parse()
-        .expect(format!("Invalid locale: {} for key: {}", locale, label.to_string()).as_str())
+        .unwrap_or_else(|err| panic!("Invalid locale: {locale} for key: {label}: {err}"))
 }
 
 #[cfg(feature = "numbers")]
 pub(super) fn get_formatter(
-    locale: &String,
-    label: impl ToString,
+    locale: &str,
+    label: impl std::fmt::Display,
 ) -> icu_decimal::FixedDecimalFormatter {
-    let label_string = label.to_string();
-    let locale = resolve_locale(locale, label);
-    let locale_string = locale.to_string();
-    icu_decimal::FixedDecimalFormatter::try_new(&locale.into(), Default::default()).expect(
-        format!(
-            "Failed to create FixedDecimalFormatter for number: {} with locale: {}",
-            label_string, locale_string,
-        )
-        .as_str(),
-    )
+    let locale = resolve_locale(locale, &label);
+    icu_decimal::FixedDecimalFormatter::try_new(&locale.clone().into(), Default::default())
+        .unwrap_or_else(|err| {
+            panic!("Failed to create FixedDecimalFormatter for {label} with locale {locale}: {err}")
+        })
 }
 
 pub(super) fn translate_by_key(
-    locale: &String,
-    key: &String,
-    args: &Vec<(String, InterpolationType)>,
+    locale: &str,
+    key: &str,
+    args: &[(String, InterpolationType)],
 ) -> String {
-    let key = key.as_str();
-
     #[cfg(feature = "numbers")]
-    let fdf = super::utils::get_formatter(locale, key);
+    let fdf = get_formatter(locale, key);
 
     let (patterns, values): (Vec<&str>, Vec<String>) = args
         .iter()
@@ -55,6 +48,5 @@ pub(super) fn translate_by_key(
         .unzip();
     let translated = t!(key, locale = locale);
 
-    let val = rust_i18n::replace_patterns(&translated, patterns.as_slice(), values.as_slice());
-    val
+    rust_i18n::replace_patterns(&translated, patterns.as_slice(), values.as_slice())
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,36 +1,24 @@
 use std::path::Path;
 
-use bevy::{
-    app::{App, Plugin, PreStartup, Update},
-    asset::{AssetServer, Handle},
-    ecs::{
-        component::Component,
-        schedule::{
-            common_conditions::{resource_changed, resource_exists, resource_removed},
-            IntoSystemConfigs,
-        },
-        system::{Commands, Query, Res, ResMut},
-    },
-    text::{Font, TextFont},
-    ui::widget::Text,
-};
+use bevy::prelude::*;
 
 use crate::{
-    components::{I18nFont, I18nNumber, I18nText},
-    prelude::{I18nComponent, I18nText2d},
-    resources::{FontFolder, FontManager, FontsLoading, I18n},
+    components::{I18nFont, I18nText, I18nText2d},
+    prelude::I18nComponent,
+    resources::{FontFolder, FontManager, I18n},
     FONT_FAMILIES,
 };
 
 /// Initializes the `bevy_simple_i18n` plugin
 ///
 /// # Example
-/// ```
+/// ```no_run
 /// use bevy::prelude::*;
 /// use bevy_simple_i18n::prelude::*;
 ///
 /// fn main() {
 ///     App::new()
+///         .add_plugins(DefaultPlugins)
 ///         .add_plugins(I18nPlugin)
 ///         .run();
 /// }
@@ -38,91 +26,81 @@ use crate::{
 pub struct I18nPlugin;
 
 impl Plugin for I18nPlugin {
-    fn build(&self, app: &mut bevy::prelude::App) {
+    fn build(&self, app: &mut App) {
         app.init_resource::<I18n>()
             .init_resource::<FontManager>()
-            .init_resource::<FontsLoading>()
+            .register_type::<I18n>()
+            .register_type::<I18nText>()
+            .register_type::<I18nText2d>()
+            .register_type::<I18nFont>()
             .add_systems(PreStartup, load_dynamic_fonts)
             .register_i18n_component::<I18nText>()
-            .register_i18n_component::<I18nText2d>()
-            .register_i18n_component::<I18nNumber>()
-            .add_systems(
-                Update,
-                monitor_font_loading.run_if(resource_exists::<FontsLoading>),
-            );
+            .register_i18n_component::<I18nText2d>();
+
+        #[cfg(feature = "numbers")]
+        app.register_type::<crate::components::I18nNumber>()
+            .register_i18n_component::<crate::components::I18nNumber>();
     }
 }
 
 pub trait I18nComponentRegistration {
     /// Registers an i18n component for automatic translation updates
-    fn register_i18n_component<T: I18nComponent + Component>(&mut self) -> &mut Self;
+    fn register_i18n_component<T: I18nComponent>(&mut self) -> &mut Self;
 }
 
 impl I18nComponentRegistration for App {
-    fn register_i18n_component<T: I18nComponent + Component>(&mut self) -> &mut Self {
-        self.add_systems(
-            Update,
-            (
-                update_text_translations::<T>.run_if(resource_removed::<FontsLoading>),
-                update_text_translations::<T>.run_if(resource_changed::<I18n>),
-            ),
-        )
+    fn register_i18n_component<T: I18nComponent>(&mut self) -> &mut Self {
+        self.add_systems(Update, update_translations::<T>)
     }
 }
 
-/// Auto updates the translations for components that have the [I18nComponent] trait
-/// and have been registered with the Bevy [App] using the [register_i18n_component] method
-/// whenever the [I18n] resource changes
-fn update_text_translations<T: I18nComponent + Component>(
-    font_manager: bevy::ecs::system::Res<FontManager>,
-    mut text_query: Query<(&mut Text, &mut TextFont, Option<&I18nFont>, &T)>,
+/// Keeps the translated text (and dynamic font) of every registered [`I18nComponent`] in sync.
+///
+/// Thanks to change detection this is cheap to run every frame: an entity's target text is only
+/// rewritten when the entity's i18n component was just added/changed, or when the global locale
+/// changed (the [`I18n`] resource was mutated).
+#[allow(clippy::type_complexity)]
+fn update_translations<T: I18nComponent>(
+    i18n: Res<I18n>,
+    font_manager: Res<FontManager>,
+    mut query: Query<(
+        &mut T::Target,
+        Option<&mut TextFont>,
+        Option<&I18nFont>,
+        Ref<T>,
+    )>,
 ) {
-    bevy::log::debug!("Updating translations");
-    for (mut text, mut text_font, dyn_font, key) in text_query.iter_mut() {
-        text.0 = key.translate();
-        if let Some(dyn_font) = dyn_font {
-            text_font.font = font_manager.get(&dyn_font.0, key.locale());
+    let locale_changed = i18n.is_changed();
+    for (mut target, text_font, dyn_font, key) in query.iter_mut() {
+        if !locale_changed && !key.is_changed() {
+            continue;
+        }
+        bevy::log::debug!("Updating translation for locale {}", key.locale());
+        **target = key.translate();
+        if let (Some(mut text_font), Some(dyn_font)) = (text_font, dyn_font) {
+            // Bevy 0.19: TextFont::font is a `FontSource` enum; Handle<Font> converts via From.
+            text_font.font = font_manager.get(&dyn_font.0, key.locale()).into();
         }
     }
 }
 
-/// Loads the dynamic fonts specified in the [FONT_FAMILIES] constant that's generated by the build script
-///
-/// TODO: Make the loading state more controllable
-fn load_dynamic_fonts(
-    mut font_manager: ResMut<FontManager>,
-    asset_server: Res<bevy::asset::AssetServer>,
-) {
+/// Loads the dynamic fonts specified in the [`FONT_FAMILIES`] constant that's generated by the
+/// build script.
+fn load_dynamic_fonts(mut font_manager: ResMut<FontManager>, asset_server: Res<AssetServer>) {
     for dyn_font in FONT_FAMILIES.iter() {
         bevy::log::debug!("Loading dynamic font family: {}", dyn_font.family);
-        let mut font_folder = FontFolder::default();
-        font_folder.fallback = asset_server.load(Path::new(dyn_font.path).join("fallback.ttf"));
+        let mut font_folder = FontFolder {
+            fallback: asset_server.load(Path::new(dyn_font.path).join("fallback.ttf")),
+            ..Default::default()
+        };
         for font in dyn_font.locales.iter() {
             bevy::log::debug!("Loading font: {}", font);
             let locale = font.split('.').next().expect("Locale is required");
             let path = Path::new(dyn_font.path).join(font);
-            let handler: Handle<Font> = asset_server.load(path);
-            font_folder.fonts.insert(locale.to_string(), handler);
+            font_folder
+                .fonts
+                .insert(locale.to_string(), asset_server.load(path));
         }
         font_manager.insert(dyn_font.family.to_string(), font_folder);
     }
-}
-
-/// Monitors the font loading state and removes the [FontsLoading] resource when all fonts are loaded
-///
-/// TODO: Make the loading state more controllable
-fn monitor_font_loading(
-    mut commands: Commands,
-    font_manager: Res<FontManager>,
-    asset_server: Res<AssetServer>,
-) {
-    for folder in font_manager.fonts.values() {
-        for font in folder.fonts.values() {
-            if !asset_server.is_loaded(font.id()) {
-                return;
-            }
-        }
-    }
-    commands.remove_resource::<FontsLoading>();
-    bevy::log::debug!("All fonts loaded");
 }

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -1,10 +1,4 @@
-use bevy::{
-    asset::Handle,
-    ecs::{reflect::ReflectResource, system::Resource},
-    reflect::Reflect,
-    text::Font,
-    utils::hashbrown::HashMap,
-};
+use bevy::{ecs::reflect::ReflectResource, platform::collections::HashMap, prelude::*, text::Font};
 use icu_locid::Locale;
 
 /// Resource for managing the current locale and getting the available locales
@@ -17,6 +11,7 @@ use icu_locid::Locale;
 /// fn update_locale(mut i18n_res: ResMut<I18n>) {
 ///     i18n_res.set_locale("en");
 /// }
+/// ```
 #[derive(Debug, Resource, Reflect)]
 #[reflect(Resource)]
 pub struct I18n {
@@ -110,7 +105,7 @@ impl FontManager {
         self.fonts.insert(family, font_folder);
     }
 
-    pub(crate) fn get(&self, family: &str, locale: String) -> Handle<Font> {
+    pub(crate) fn get(&self, family: &str, locale: impl Into<String>) -> Handle<Font> {
         if let Some(folder) = self.fonts.get(family) {
             bevy::log::debug!("Found font family: {}", family);
             folder.get(locale)
@@ -120,8 +115,3 @@ impl FontManager {
         }
     }
 }
-
-/// Hacky resource to signal that fonts are still loading
-#[derive(Debug, Reflect, Default, Resource)]
-#[reflect(Resource)]
-pub(crate) struct FontsLoading;

--- a/tests/translation.rs
+++ b/tests/translation.rs
@@ -1,0 +1,95 @@
+//! End-to-end tests that the i18n components actually translate, and react to locale changes.
+//!
+//! These run a real (headless) Bevy `App`, so they double as a regression guard for the
+//! "doesn't translate anything" report in
+//! <https://github.com/TurtIeSocks/bevy_simple_i18n/issues/7>.
+
+use bevy::asset::AssetPlugin;
+use bevy::prelude::*;
+use bevy::text::Font;
+use bevy_simple_i18n::prelude::*;
+
+/// Builds the smallest `App` that can drive the plugin: an asset server (so the font loader has
+/// somewhere to read from) plus the registered `Font` asset that `load_dynamic_fonts` produces.
+fn test_app() -> App {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_plugins(AssetPlugin::default())
+        .init_asset::<Font>()
+        .add_plugins(I18nPlugin);
+    app
+}
+
+fn text(app: &App, entity: Entity) -> String {
+    app.world()
+        .get::<Text>(entity)
+        .expect("the `#[require(Text)]` attribute should have inserted a Text component")
+        .0
+        .clone()
+}
+
+#[test]
+fn translates_with_a_forced_locale() {
+    let mut app = test_app();
+    let en = app
+        .world_mut()
+        .spawn(I18nText::new("hello").with_locale("en"))
+        .id();
+    let ja = app
+        .world_mut()
+        .spawn(I18nText::new("hello").with_locale("ja"))
+        .id();
+
+    app.update();
+
+    assert_eq!(text(&app, en), "Hello world");
+    assert_eq!(text(&app, ja), "こんにちは世界");
+}
+
+#[test]
+fn updates_when_the_global_locale_changes() {
+    let mut app = test_app();
+    let id = app.world_mut().spawn(I18nText::new("hello")).id();
+
+    app.world_mut().resource_mut::<I18n>().set_locale("en");
+    app.update();
+    assert_eq!(text(&app, id), "Hello world");
+
+    app.world_mut().resource_mut::<I18n>().set_locale("ja");
+    app.update();
+    assert_eq!(text(&app, id), "こんにちは世界");
+}
+
+/// Regression test: before the 0.18 rewrite the update system hard-coded `&mut Text`, so
+/// `I18nText2d` entities (which carry `Text2d`, not `Text`) never re-translated when the locale
+/// changed. The associated `I18nComponent::Target` now drives the correct component.
+#[test]
+fn text2d_updates_when_the_global_locale_changes() {
+    let mut app = test_app();
+    let id = app.world_mut().spawn(I18nText2d::new("hello")).id();
+
+    app.world_mut().resource_mut::<I18n>().set_locale("en");
+    app.update();
+    assert_eq!(app.world().get::<Text2d>(id).unwrap().0, "Hello world");
+
+    app.world_mut().resource_mut::<I18n>().set_locale("ja");
+    app.update();
+    assert_eq!(app.world().get::<Text2d>(id).unwrap().0, "こんにちは世界");
+}
+
+#[test]
+fn interpolates_arguments() {
+    let mut app = test_app();
+    let id = app
+        .world_mut()
+        .spawn(
+            I18nText::new("messages.hello")
+                .with_arg("name", "Bevy")
+                .with_locale("en"),
+        )
+        .id();
+
+    app.update();
+
+    assert_eq!(text(&app, id), "Hello, Bevy");
+}

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.15.0-rc.3" }
+bevy = { version = "0.19" }
 bevy_simple_i18n = { path = "../" }

--- a/web/src/main.rs
+++ b/web/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, i18n_res: Res<I18n>) {
-    commands.spawn(Camera2d::default());
+    commands.spawn(Camera2d);
     commands
         .spawn(Node {
             width: Val::Percent(100.),
@@ -137,16 +137,16 @@ fn setup(mut commands: Commands, i18n_res: Res<I18n>) {
                                     border: UiRect::all(Val::Px(5.0)),
                                     justify_content: JustifyContent::Center,
                                     align_items: AlignItems::Center,
+                                    border_radius: BorderRadius::MAX,
                                     ..default()
                                 },
-                                BorderColor(Color::BLACK),
-                                BorderRadius::MAX,
+                                BorderColor::all(Color::BLACK),
                                 BackgroundColor(Color::srgb(0.15, 0.15, 0.15)),
                             ))
                             .with_child((
                                 Text::new(locale),
                                 TextFont {
-                                    font_size: 50.0,
+                                    font_size: FontSize::Px(50.0),
                                     ..default()
                                 },
                                 TextColor(Color::srgb(0.9, 0.9, 0.9)),
@@ -156,18 +156,16 @@ fn setup(mut commands: Commands, i18n_res: Res<I18n>) {
         });
 }
 
+#[allow(clippy::type_complexity)]
 fn button_system(
     interaction_query: Query<(&Interaction, &Children), (Changed<Interaction>, With<Button>)>,
     text_query: Query<&Text>,
     mut i18n_res: ResMut<I18n>,
 ) {
     for (interaction, children) in interaction_query.iter() {
-        match *interaction {
-            Interaction::Pressed => {
-                let text = text_query.get(children[0]).unwrap().clone().0;
-                i18n_res.set_locale(text);
-            }
-            _ => {}
+        if *interaction == Interaction::Pressed {
+            let text = text_query.get(children[0]).unwrap().0.clone();
+            i18n_res.set_locale(text);
         }
     }
 }


### PR DESCRIPTION
Brings the crate up to date with **Bevy 0.19** (`0.19.0`), modernizes it toward idiomatic Bevy ECS, and fixes both open issues. Bumps the crate to **0.2.0** (breaking).

## Migration: Bevy 0.15 → 0.19
Walks the 0.16/0.17/0.18/0.19 breaking changes:
- `ecs::system::Resource` → `ecs::resource::Resource`, `utils::hashbrown::HashMap` → `platform::collections::HashMap`
- `Text2d` moved to `bevy_sprite` (added the feature)
- Component hook API (`register_component_hooks`/`ComponentHooks` → `on_add()` + `HookContext` + `type Mutability`) — then removed entirely (see below)
- `IntoSystemConfigs` → `IntoScheduleConfigs`
- `BorderColor` is now per-side (`BorderColor::all`), `BorderRadius` moved into `Node` (examples + web demo)
- **0.19 text rework:** `TextFont::font` is now a `FontSource` enum (a `Handle<Font>` converts via `.into()`) and `TextFont::font_size` is now a `FontSize` enum (`FontSize::Px(..)`)

## Idiomatic rewrite (the "make it more Bevy" part)
- **Required components instead of `on_add` hooks.** All four components are now plain `#[derive(Component)]` with `#[require(Text/Text2d/TextFont)]`; the target component is auto-inserted. The four hand-written `impl Component { fn register_component_hooks … }` blocks are gone.
- **One generic change-detection system** replaces the hooks + per-type locale systems. `update_translations::<T>` uses `Ref<T>` + `Res<I18n>` change detection, so initial spawn and locale changes flow through one cheap path (no work unless something actually changed).
- **Associated `I18nComponent::Target` type** so the system writes to the correct component (`Text` vs `Text2d`).
- Reflect types registered with the type registry; `I18nNumber` correctly gated behind the `numbers` feature in the plugin; `&String`/`&Vec` → `&str`/`&[…]`; `expect(format!(…))` → `unwrap_or_else`; `bevy::prelude` imports; **zero clippy warnings**, `rustfmt` clean.
- Removed the self-described *"hacky"* `FontsLoading` resource + `monitor_font_loading` system. Text now renders immediately and fonts stream in async like any other Bevy asset. *(Behavior change — flagged below.)*

## 🐛 Bug found & fixed
`I18nText2d` never re-translated on locale change: the shared update system hard-coded `Query<&mut Text, …>`, so `Text2d`-backed entities were skipped after initial spawn. The associated `Target` type fixes this — covered by a regression test.

## Fixes #6 (breaks in workspace projects)
- **Build no longer fails without an assets folder.** Root cause: when discovery failed, the build script emitted no `rust_i18n::i18n!(…)`, leaving the `t!` macro with no backend → hard compile error. It now always emits one (falling back to `"locales"`). Verified `rust_i18n::i18n!` tolerates a missing dir.
- Always forward-slash emitted asset paths (cross-platform/wasm).
- Clear, actionable "assets not found" warning pointing at `BEVY_ASSET_PATH`.
- README now documents `BEVY_ASSET_PATH` + workspace setup.
- **Honest limitation:** a build script can't know which member crate's `assets` Bevy loads at runtime, so arbitrary workspace layouts still need `BEVY_ASSET_PATH`. That half is improved + documented rather than fully auto-solved.

## Fixes #7 (crates.io is stale / "doesn't translate")
The published `0.1.2` predates the build-script fix. Bumped to `0.2.0` + added `CHANGELOG.md`. **Action needed from maintainer:** run `cargo publish` (I can't publish on your behalf).

## Verification
- `cargo clippy --workspace --all-targets` — 0 warnings
- `cargo test --workspace` — 6 doctests + **4 new headless integration tests** (translation, per-entity locale, locale-change reactivity, interpolation, Text2d regression)
- `cargo build --examples` + web crate build green
- `cargo fmt --all --check` clean

## ⚠️ Behavior change to review
Dropping `FontsLoading` means text appears immediately instead of waiting for all fonts to finish loading; a locale's font may briefly fall back before its file streams in. Trivial to restore if you'd rather keep the gate — say the word.

## Further idiomatic suggestions (not applied — your call)
1. **Runtime-loaded locales instead of compile-time embedding.** This is the README's stated long-term goal and would fix the entire `BEVY_ASSET_PATH`/workspace class (#6) at the root, plus remove the `build.rs` heuristics. Biggest lever.
2. **Observers over a polling system.** A locale-change `Event`/observer (Bevy 0.16+) would avoid iterating every i18n entity each frame — worth it at high entity counts.
3. **Fallible systems instead of `panic!`.** `f64_to_fd`/`get_formatter` panic on bad input; Bevy supports `Result`-returning systems — return `BevyError` and log instead of crashing the app.
4. **Dedup `I18nText`/`I18nText2d`.** They're identical except `Target`; a small declarative macro would remove the duplication. I kept them explicit here for cleaner public rustdoc/IDE output — a deliberate trade-off.
5. **Type the locale.** Store `icu_locid::Locale` instead of `String` in `I18n`/components to validate earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)